### PR TITLE
Document Gameplay Tags

### DIFF
--- a/content/scripting/gameplaytags.md
+++ b/content/scripting/gameplaytags.md
@@ -6,10 +6,6 @@ sort_by = "weight"
 
 Gameplay Tags are used in many unreal systems. See the [Unreal Documentation on Gameplay Tags](https://docs.unrealengine.com/5.1/en-US/using-gameplay-tags-in-unreal-engine/) for more details.
 
-During the X* phase all defined** `FGameplayTag` will be automatically bound to the global object `GameplayTags`, with all non-alphanumeric characters (including the dot separators) turned into underscore `_`.
+All `FGameplayTag` will automatically be bound to the global object `GameplayTags`. All non-alphanumeric characters, including the dot separators, are turned into underscore `_`.
 
-// Assuming there is a GameplayTag named "UI.Action.Escape"
-FGameplayTag EscapeAction = GameplayTags::UI_Action_Escape;
-
-*=  lifecyle events. when is this? I only got the hyphen error during our packaged builds and not locally
-**= is there a limitation? does it have to be in an .ini file?
+<div class="code_block" style="color: #d4d4d4;background-color: #1e1e1e;font-family: 'Terminus (TTF) for Windows', Consolas, 'Courier New', monospace;font-weight: normal;font-size: 14px;line-height: 19px;white-space: pre;"><div><span style="color: #6a9955;">// Assuming there is a GameplayTag named "UI.Action.Escape"</span></div><div><span style="color: #4ec9b0;">FGameplayTag</span><span style="color: #d4d4d4;"> </span><span style="color: #9cdcfe;">TheTag</span><span style="color: #d4d4d4;"> = <span style="color: #4ec9b0">GameplayTags</span></span><span style="color: #d4d4d4;">::</span><span style="color: #9cdcfe;">UI_Action_Escape<span style="color: #d4d4d4">;</span></span></div></div>

--- a/content/scripting/gameplaytags.md
+++ b/content/scripting/gameplaytags.md
@@ -1,0 +1,15 @@
++++
+title = "GameplayTags"
+weight = 105
+sort_by = "weight"
++++
+
+Gameplay Tags are used in many unreal systems. See the [Unreal Documentation on Gameplay Tags](https://docs.unrealengine.com/5.1/en-US/using-gameplay-tags-in-unreal-engine/) for more details.
+
+During the X* phase all defined** `FGameplayTag` will be automatically bound to the global object `GameplayTags`, with all non-alphanumeric characters (including the dot separators) turned into underscore `_`.
+
+// Assuming there is a GameplayTag named "UI.Action.Escape"
+FGameplayTag EscapeAction = GameplayTags::UI_Action_Escape;
+
+*=  lifecyle events. when is this? I only got the hyphen error during our packaged builds and not locally
+**= is there a limitation? does it have to be in an .ini file?


### PR DESCRIPTION
We were using `FGameplayTag::RequestGameplayTag(n"My.Tag")` because we didn't know `GameplayTags::My_Tag` existed. Adding some documentation to save others the trouble.